### PR TITLE
add: filtering the token for chart

### DIFF
--- a/src/components/swap/components/swap.tsx
+++ b/src/components/swap/components/swap.tsx
@@ -20,6 +20,32 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useSwapStore } from '../stores/use-swap-store'
 import { ESwapMode } from '../swap.models'
 
+
+const isStable = (token: string) => {
+  const STABLE_TOKENS = [
+    "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",  // usdc
+    "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",  // usdt
+    "So11111111111111111111111111111111111111112"    // sol
+  ];
+  return STABLE_TOKENS.includes(token);
+}
+
+const getTargetToken = (tokenA: string, tokenB: string) => {
+  const aStable = isStable(tokenA);
+  const bStable = isStable(tokenB);
+
+  // Rule 1: If only one is stable, return the other
+  if (aStable && !bStable) return tokenB;
+  if (!aStable && bStable) return tokenA;
+
+  // Rule 2: If both are stable, return tokenB
+  if (aStable && bStable) return tokenB;
+
+  // Rule 3: Both are alt/meme, return the buyingToken
+  return tokenB;
+}
+
+
 const validateAmount = (value: string, decimals: number = 6): boolean => {
   if (value === '') return true
 
@@ -306,9 +332,11 @@ export function Swap({ setTokenMint }: Props) {
 
   useEffect(() => {
     if (setTokenMint) {
-      setTokenMint(outputTokenMint)
+      const tokenForChart = getTargetToken(inputTokenMint, outputTokenMint)
+      console.log('tokenForChart:', tokenForChart)
+      setTokenMint(tokenForChart)
     }
-  }, [outputTokenMint, setTokenMint])
+  }, [inputTokenMint, outputTokenMint, setTokenMint])
 
   useEffect(() => {
     if (inputs) {


### PR DESCRIPTION
- [x] select the token for chart based in the following 

> rule
1. if one token in pair is USDC, SOL, or USDT:
   - show the chart for the OTHER token in the pair
2. if both tokens in pair are stable (SOL, USDC, USDT):
   - show chart of "buying" token
3. if both tokens are memecoin/altcoin (i.e. not SOL, USDC, USDT):
   - show chart of "buying" token 