### PR TITLE
fix: TAP-1040

### DIFF
--- a/src/components/common/left-side-menu/left-side-menu.tsx
+++ b/src/components/common/left-side-menu/left-side-menu.tsx
@@ -8,9 +8,11 @@ import { Button, ButtonVariant } from '@/components/ui/button'
 import { Lock, MessageCircle } from 'lucide-react'
 import { useState } from 'react'
 import { ProfileInfos } from './profile-infos'
+import { useDriftUsers } from '@/components/trade/hooks/drift/use-drift-users'
 
 export function LeftSideMenu() {
   const [isFundsModalOpen, setIsFundsModalOpen] = useState<boolean>(false)
+  const { accountIds } = useDriftUsers()
 
   return (
     <div className="sticky z-20 left-0 top-topbar pt-5 bottom-0 inset-y-0 w-sidebar-left shrink-0 h-screen-minus-topbar">
@@ -26,14 +28,18 @@ export function LeftSideMenu() {
           <LowFeeTrades />
         </div>
         <div className="flex flex-col items-center gap-4">
-          <Button
-            variant={ButtonVariant.OUTLINE}
-            className="w-full"
-            onClick={() => setIsFundsModalOpen(true)}
-          >
-            <Lock size={16} />
-            Unlock Perpetuals
-          </Button>
+          {
+            !accountIds.length ? (
+              <Button
+                variant={ButtonVariant.OUTLINE}
+                className="w-full"
+                onClick={() => setIsFundsModalOpen(true)}
+              >
+                <Lock size={16} />
+                Unlock Perpetuals
+              </Button>
+            ) : (<></>)
+          }
           <LanguageSwitcher />
           <Button
             variant={ButtonVariant.OUTLINE_WHITE}


### PR DESCRIPTION
- [x] hide "unlock perpetuals" button when user has a drift account 