### PR TITLE
Improved profile handling and fixed various UI issues TAP-1202

### DIFF
--- a/src/app/api/followers/add/route.ts
+++ b/src/app/api/followers/add/route.ts
@@ -1,11 +1,7 @@
 import { fetchTapestry } from '@/components/tapestry/api/fetch-tapestry'
+import { IFollowersAddRemoveInput } from '@/components/tapestry/models/profiles.models'
 import { FetchMethod } from '@/utils/api'
 import { NextRequest, NextResponse } from 'next/server'
-
-export interface IFollowersAddRemoveInput {
-  followerUsername: string
-  followeeUsername: string
-}
 
 export async function POST(req: NextRequest) {
   try {

--- a/src/app/api/followers/add/route.ts
+++ b/src/app/api/followers/add/route.ts
@@ -1,66 +1,36 @@
+import { fetchTapestry } from '@/components/tapestry/api/fetch-tapestry'
 import { FetchMethod } from '@/utils/api'
-import { fetchTapestryServer } from '@/utils/api/tapestry-server'
 import { NextRequest, NextResponse } from 'next/server'
 
-interface FollowRequestBody {
-  followerUser: { username: string }
-  followeeUser: { username: string }
-}
-
-// Define the expected response type
-interface TapestryResponse {
-  error?: string
-  // Add other expected response properties here
-  [key: string]: any // For other unknown properties
+export interface IFollowersAddRemoveInput {
+  followerUsername: string
+  followeeUsername: string
 }
 
 export async function POST(req: NextRequest) {
   try {
-    const { followerUser, followeeUser }: FollowRequestBody = await req.json()
+    const { followerUsername, followeeUsername }: IFollowersAddRemoveInput =
+      await req.json()
 
-    if (!followerUser || !followeeUser) {
+    if (!followerUsername || !followeeUsername) {
       return NextResponse.json(
-        { error: 'followerUser and followeeUser are required' },
+        { error: 'followerUsername and followeeUsername are required' },
         { status: 400 }
       )
     }
 
-    const bodyData = {
-      startId: followerUser.username,
-      endId: followeeUser.username,
-    }
-
-    const response = await fetchTapestryServer<TapestryResponse>({
+    const response = await fetchTapestry({
       endpoint: 'followers/add',
       method: FetchMethod.POST,
-      data: bodyData,
+      body: {
+        startId: followerUsername,
+        endId: followeeUsername,
+      },
     })
 
     return NextResponse.json(response)
   } catch (error: any) {
-    // Only log non-404 errors
-    if (!error.message?.includes('status: 404')) {
-      console.error('Error processing follow request:', error)
-    }
-
-    // Handle specific error cases
-    if (error.message?.includes('status: 404')) {
-      return NextResponse.json(
-        { error: 'Follow endpoint not found' },
-        { status: 404 }
-      )
-    }
-
-    if (
-      error.message?.includes('status: 401') ||
-      error.message?.includes('status: 403')
-    ) {
-      return NextResponse.json(
-        { error: 'Authentication failed' },
-        { status: 401 }
-      )
-    }
-
+    console.error('Error processing follow request:', error)
     return NextResponse.json(
       { error: error.message || 'Internal Server Error' },
       { status: 500 }

--- a/src/app/api/followers/remove/route.ts
+++ b/src/app/api/followers/remove/route.ts
@@ -1,5 +1,5 @@
-import { IFollowersAddRemoveInput } from '@/app/api/followers/add/route'
 import { fetchTapestry } from '@/components/tapestry/api/fetch-tapestry'
+import { IFollowersAddRemoveInput } from '@/components/tapestry/models/profiles.models'
 import { FetchMethod } from '@/utils/api'
 import { NextRequest, NextResponse } from 'next/server'
 

--- a/src/app/api/followers/remove/route.ts
+++ b/src/app/api/followers/remove/route.ts
@@ -1,40 +1,32 @@
-import { socialfi } from '@/utils/socialfi'
+import { IFollowersAddRemoveInput } from '@/app/api/followers/add/route'
+import { fetchTapestry } from '@/components/tapestry/api/fetch-tapestry'
+import { FetchMethod } from '@/utils/api'
 import { NextRequest, NextResponse } from 'next/server'
-
-interface UnfollowRequestBody {
-  followerUser: { username: string }
-  followeeUser: { username: string }
-}
-
-interface TapestryResponse {
-  error?: string
-  [key: string]: any
-}
 
 export async function POST(req: NextRequest) {
   try {
-    const { followerUser, followeeUser }: UnfollowRequestBody = await req.json()
+    const { followerUsername, followeeUsername }: IFollowersAddRemoveInput =
+      await req.json()
 
-    if (!followerUser || !followeeUser) {
+    if (!followerUsername || !followeeUsername) {
       return NextResponse.json(
-        { error: 'followerUser and followeeUser are required' },
+        { error: 'followerUsername and followeeUsername are required' },
         { status: 400 }
       )
     }
 
-    const bodyData = {
-      startId: followerUser.username,
-      endId: followeeUser.username,
-    }
-
-    const response = await socialfi.unfollowUser(
-      bodyData.startId,
-      bodyData.endId
-    )
+    const response = await fetchTapestry({
+      endpoint: 'followers/remove',
+      method: FetchMethod.POST,
+      body: {
+        startId: followerUsername,
+        endId: followeeUsername,
+      },
+    })
 
     return NextResponse.json(response)
   } catch (error: any) {
-    console.error('Error processing unfollow request:', error)
+    console.error('Error processing follow request:', error)
     return NextResponse.json(
       { error: error.message || 'Internal Server Error' },
       { status: 500 }

--- a/src/app/api/profiles/[username]/route.ts
+++ b/src/app/api/profiles/[username]/route.ts
@@ -40,23 +40,11 @@ export async function GET(request: NextRequest, context: RouteContext) {
 
     return NextResponse.json(data)
   } catch (error) {
-    console.error('[API] Error fetching profile:', error)
+    console.warn('[API] Profile not found or error fetching:', error)
 
-    // Handle 404 specifically
-    if (
-      error instanceof Error &&
-      error.message.includes('API endpoint not found')
-    ) {
-      return NextResponse.json(
-        { error: `Profile not found: ${username}` },
-        { status: 404 }
-      )
-    }
-
-    // Handle other errors
     return NextResponse.json(
-      { error: 'Failed to fetch profile' },
-      { status: 500 }
+      { error: `Profile not found: ${username}` },
+      { status: 404 }
     )
   }
 }

--- a/src/components/common/follow-button.tsx
+++ b/src/components/common/follow-button.tsx
@@ -7,7 +7,7 @@ import { useGetFollowing } from '@/components/tapestry/hooks/use-get-following'
 import { useUnfollowUser } from '@/components/tapestry/hooks/use-unfollow-user'
 import { Button, ButtonProps, ButtonSize, ButtonVariant } from '@/components/ui'
 import { useCurrentWallet } from '@/utils/use-current-wallet'
-import { UserCheck, UserPlus } from 'lucide-react'
+import { UserMinus, UserPlus } from 'lucide-react'
 import { useState } from 'react'
 
 interface Props extends Omit<ButtonProps, 'children'> {
@@ -121,9 +121,9 @@ export function FollowButton({
     <div className="flex flex-col items-center gap-1">
       <Button
         {...props}
-        onClick={handleFollow}
+        onClick={isFollowing ? handleUnfollow : handleFollow}
         loading={loadingFollowersState}
-        disabled={loading || isFollowing}
+        disabled={loading}
         variant={ButtonVariant.SECONDARY_SOCIAL}
       >
         {!!children ? (
@@ -132,10 +132,10 @@ export function FollowButton({
           <>
             {isFollowing ? (
               isIcon ? (
-                <UserCheck size={iconSize} />
+                <UserMinus size={iconSize} />
               ) : (
                 <>
-                  <UserCheck size={iconSize} /> Following
+                  <UserMinus size={iconSize} /> Unfollow
                 </>
               )
             ) : isIcon ? (
@@ -148,16 +148,6 @@ export function FollowButton({
           </>
         )}
       </Button>
-      {/* {isFollowing && (
-        <Button
-          variant={ButtonVariant.LINK}
-          onClick={handleUnfollow}
-          className="text-xs"
-          disabled={loading}
-        >
-          Unfollow
-        </Button>
-      )} */}
     </div>
   )
 }

--- a/src/components/common/follow-button.tsx
+++ b/src/components/common/follow-button.tsx
@@ -4,6 +4,7 @@ import { useFollowUser } from '@/components/tapestry/hooks/use-follow-user'
 import { useGetFollowers } from '@/components/tapestry/hooks/use-get-followers'
 import { useGetFollowersState } from '@/components/tapestry/hooks/use-get-followers-state'
 import { useGetFollowing } from '@/components/tapestry/hooks/use-get-following'
+import { useUnfollowUser } from '@/components/tapestry/hooks/use-unfollow-user'
 import { Button, ButtonProps, ButtonSize, ButtonVariant } from '@/components/ui'
 import { useCurrentWallet } from '@/utils/use-current-wallet'
 import { UserCheck, UserPlus } from 'lucide-react'
@@ -24,7 +25,7 @@ export function FollowButton({
   ...props
 }: Props) {
   const { followUser, loading: followUserLoading } = useFollowUser()
-  //  const { unfollowUser, loading: unfollowUserLoading } = useUnfollowUser()
+  const { unfollowUser, loading: unfollowUserLoading } = useUnfollowUser()
   const { refetch: refetchCurrentUser, loading: loadingCurrentUser } =
     useCurrentWallet()
   const { refetch: refetchGetFollowing } = useGetFollowing({
@@ -34,6 +35,7 @@ export function FollowButton({
     username: followeeUsername,
   })
   const [refetchLoading, setRefetchLoading] = useState(false)
+
   const {
     data,
     loading: loadingFollowersState,
@@ -42,17 +44,22 @@ export function FollowButton({
     followeeUsername,
     followerUsername,
   })
+
   const [isFollowingOptimistic, setIsFollowingOptimistic] = useState(
     data?.isFollowing
   )
 
-  const loading = followUserLoading || refetchLoading || loadingCurrentUser // || unfollowUserLoading
+  const loading =
+    followUserLoading ||
+    refetchLoading ||
+    loadingCurrentUser ||
+    unfollowUserLoading
 
   const refetch = async () => {
     setRefetchLoading(true)
 
-    // revalidateServerCache(`/api/profiles/${followerUsername}/following`)
-    // revalidateServerCache(`/api/profiles/${followeeUsername}/followers`)
+    //revalidateServerCache(`/api/profiles/${followerUsername}/following`)
+    //revalidateServerCache(`/api/profiles/${followeeUsername}/followers`)
 
     await Promise.all([
       refetchCurrentUser(),
@@ -68,8 +75,8 @@ export function FollowButton({
 
     try {
       await followUser({
-        followerUser: { username: followerUsername },
-        followeeUser: { username: followeeUsername },
+        followerUsername,
+        followeeUsername,
       })
       await refetch()
       onFollowSuccess?.()
@@ -81,22 +88,22 @@ export function FollowButton({
     }
   }
 
-  //   const handleUnfollow = async () => {
-  //     setIsFollowingOptimistic(false)
+  const handleUnfollow = async () => {
+    setIsFollowingOptimistic(false)
 
-  //     try {
-  //       await unfollowUser({
-  //         followerUsername,
-  //         followeeUsername,
-  //       })
-  //       await refetch()
-  //     } catch (error) {
-  //       console.error('Failed to unfollow:', error)
-  //       setIsFollowingOptimistic(true)
-  //     } finally {
-  //       refetchFollowersState()
-  //     }
-  //   }
+    try {
+      await unfollowUser({
+        followerUsername,
+        followeeUsername,
+      })
+      await refetch()
+    } catch (error) {
+      console.error('Failed to unfollow:', error)
+      setIsFollowingOptimistic(true)
+    } finally {
+      refetchFollowersState()
+    }
+  }
 
   if (followerUsername === followeeUsername) {
     return null

--- a/src/components/common/left-side-menu/menu.tsx
+++ b/src/components/common/left-side-menu/menu.tsx
@@ -3,7 +3,6 @@
 import { DialectNotificationsComponent } from '@/components/notifications/dialect-notifications-component'
 import { Button, ButtonVariant } from '@/components/ui/button'
 import { route } from '@/utils/route'
-import { useCurrentWallet } from '@/utils/use-current-wallet'
 import { cn } from '@/utils/utils'
 import {
   ArrowRightLeft,
@@ -12,7 +11,6 @@ import {
   House,
   LucideIcon,
   PocketKnife,
-  User,
 } from 'lucide-react'
 import { usePathname } from 'next/navigation'
 import { UrlObject } from 'url'
@@ -23,8 +21,6 @@ interface Props {
 }
 
 export function Menu({ setOpen }: Props) {
-  const { mainProfile } = useCurrentWallet()
-
   return (
     <div className="space-y-4 md:space-y-2">
       <Entry title="Home" icon={House} href={route('home')} setOpen={setOpen} />

--- a/src/components/common/left-side-menu/profile-infos.tsx
+++ b/src/components/common/left-side-menu/profile-infos.tsx
@@ -15,7 +15,11 @@ import { useCurrentWallet } from '@/utils/use-current-wallet'
 import { EllipsisVerticalIcon, LogOutIcon } from 'lucide-react'
 import Image from 'next/image'
 
-export function ProfileInfos() {
+interface Props {
+  setOpen?: (open: boolean) => void
+}
+
+export function ProfileInfos({ setOpen }: Props) {
   const { mainProfile, isLoggedIn, walletAddress, logout, setShowAuthFlow } =
     useCurrentWallet()
   const { balance } = useGetBalance({ walletAddress })
@@ -40,7 +44,9 @@ export function ProfileInfos() {
               className="flex items-center gap-2 p-0 hover:bg-transparent"
               variant={ButtonVariant.GHOST}
               href={route('entity', { id: mainProfile.username })}
-              style={{ boxShadow: 'none' }}
+              onClick={() => {
+                setOpen && setOpen(false)
+              }}
             >
               <Avatar
                 className="w-8 md:w-6"
@@ -48,12 +54,10 @@ export function ProfileInfos() {
                 imageUrl={mainProfile.image}
                 size={40}
               />
-              <span className="flex items-center gap-1">
+              <div className="flex items-center gap-1 text-lg md:text-sm">
                 <p>hi</p>
-                <p className="font-medium max-w-[8rem] truncate">
-                  {mainProfile.username}
-                </p>
-              </span>
+                <p className="max-w-[8rem] truncate">{mainProfile.username}</p>
+              </div>
             </Button>
             <div className="desktop">
               <DropdownMenu>
@@ -83,6 +87,9 @@ export function ProfileInfos() {
           <div className="flex items-center gap-1">
             <Button
               isInvisible
+              onClick={() => {
+                setOpen && setOpen(false)
+              }}
               href={route('entity', {
                 id: SSE_TOKEN_MINT,
               })}

--- a/src/components/common/left-side-menu/solid-score/solid-score-dialog.tsx
+++ b/src/components/common/left-side-menu/solid-score/solid-score-dialog.tsx
@@ -4,17 +4,11 @@ import { useSolidScore } from '@/components/common/hooks/use-solid-score'
 import { ScoreArc } from '@/components/common/left-side-menu/solid-score/score-arc'
 import { SolidScoreBadges } from '@/components/common/left-side-menu/solid-score/solid-score-badges'
 import { SolidScoreValue } from '@/components/common/left-side-menu/solid-score/solid-score-value'
-import {
-  Button,
-  ButtonVariant,
-  Dialog,
-  DialogContent,
-  DialogHeader,
-} from '@/components/ui'
+import { Button, Dialog, DialogContent, DialogHeader } from '@/components/ui'
+import { ValidatedImage } from '@/components/ui/validated-image/validated-image'
 import { formatSmartNumber } from '@/utils/formatting/format-number'
 import { useCurrentWallet } from '@/utils/use-current-wallet'
 import { DialogTitle } from '@radix-ui/react-dialog'
-import { UserRoundPlus } from 'lucide-react'
 import Image from 'next/image'
 
 export interface Props {
@@ -46,7 +40,7 @@ export function SolidScoreDialog({ open, setOpen }: Props) {
             <p className="text-md">My SOLID Score is...</p>
             <div className="flex items-center gap-2 justify-center">
               {mainProfile?.image && (
-                <Image
+                <ValidatedImage
                   src={mainProfile?.image}
                   alt="profile image"
                   width={20}
@@ -78,7 +72,6 @@ export function SolidScoreDialog({ open, setOpen }: Props) {
         </div>
 
         <Button
-          variant={ButtonVariant.OUTLINE_SOCIAL}
           onClick={() => setOpen(false)}
           href={`https://x.com/intent/tweet?text=${encodeURIComponent(
             `My SOLID Score is ${formatSmartNumber(
@@ -92,7 +85,6 @@ export function SolidScoreDialog({ open, setOpen }: Props) {
           newTab
           rel="noopener noreferrer"
         >
-          <UserRoundPlus size={16} />
           Share
         </Button>
       </DialogContent>

--- a/src/components/common/mobile-menu/mobile-menu.tsx
+++ b/src/components/common/mobile-menu/mobile-menu.tsx
@@ -42,7 +42,7 @@ export function MobileMenu({ open, setOpen }: Props) {
           </h1>
         </div>
         <div className="px-6 pb-6 w-full flex flex-col flex-1">
-          <ProfileInfos />
+          <ProfileInfos setOpen={setOpen} />
           <Separator className="mt-4" />
           <div className="flex-1">
             <Menu setOpen={setOpen} />

--- a/src/components/common/token-holders.tsx
+++ b/src/components/common/token-holders.tsx
@@ -2,9 +2,9 @@
 
 import { IGetProfileOwnSpecificToken } from '@/components/tapestry/models/token.models'
 import { Button, ButtonVariant } from '@/components/ui'
+import { ValidatedImage } from '@/components/ui/validated-image/validated-image'
 import { route } from '@/utils/route'
 import { cn } from '@/utils/utils'
-import Image from 'next/image'
 
 interface Props {
   data: IGetProfileOwnSpecificToken
@@ -32,7 +32,7 @@ export function TokenHolders({ data }: Props) {
             )}
           >
             {profile.image && (
-              <Image
+              <ValidatedImage
                 src={profile.image}
                 alt="profile"
                 fill

--- a/src/components/profile/components/profile-with-username.tsx
+++ b/src/components/profile/components/profile-with-username.tsx
@@ -1,10 +1,8 @@
 'use client'
 
-import { FullPageSpinner } from '@/components/ui'
+import { Button, ButtonVariant, FullPageSpinner } from '@/components/ui'
 import { route } from '@/utils/route'
 import { useCurrentWallet } from '@/utils/use-current-wallet'
-import { useRouter } from 'next/navigation'
-import { useEffect } from 'react'
 import { useGetProfileInfo } from '../hooks/use-get-profile-info'
 import { ProfileContent } from './profile-content'
 
@@ -13,25 +11,25 @@ interface Props {
 }
 
 export function ProfileWithUsername({ username }: Props) {
-  const router = useRouter()
   const { mainProfile } = useCurrentWallet()
   const { profileInfo, loading, error } = useGetProfileInfo({
     username,
     mainUsername: mainProfile?.username,
   })
 
-  useEffect(() => {
-    if (error) {
-      router.push(route('home'))
-    }
-  }, [error, router])
-
   if (loading) {
     return <FullPageSpinner />
   }
 
-  if (!profileInfo) {
-    return null
+  if (error || !profileInfo) {
+    return (
+      <div className="w-full flex items-center justify-center pt-[200px] text-lg flex-col gap-4">
+        Profile not found
+        <Button variant={ButtonVariant.OUTLINE} href={route('home')}>
+          go back home
+        </Button>
+      </div>
+    )
   }
 
   return (

--- a/src/components/profile/components/profile-with-username.tsx
+++ b/src/components/profile/components/profile-with-username.tsx
@@ -1,7 +1,10 @@
 'use client'
 
 import { FullPageSpinner } from '@/components/ui'
+import { route } from '@/utils/route'
 import { useCurrentWallet } from '@/utils/use-current-wallet'
+import { useRouter } from 'next/navigation'
+import { useEffect } from 'react'
 import { useGetProfileInfo } from '../hooks/use-get-profile-info'
 import { ProfileContent } from './profile-content'
 
@@ -10,11 +13,18 @@ interface Props {
 }
 
 export function ProfileWithUsername({ username }: Props) {
+  const router = useRouter()
   const { mainProfile } = useCurrentWallet()
-  const { profileInfo, loading } = useGetProfileInfo({
+  const { profileInfo, loading, error } = useGetProfileInfo({
     username,
     mainUsername: mainProfile?.username,
   })
+
+  useEffect(() => {
+    if (error) {
+      router.push(route('home'))
+    }
+  }, [error, router])
 
   if (loading) {
     return <FullPageSpinner />

--- a/src/components/profile/components/profile-with-wallet.tsx
+++ b/src/components/profile/components/profile-with-wallet.tsx
@@ -1,11 +1,10 @@
 'use client'
 
 import { useGetProfiles } from '@/components/tapestry/hooks/use-get-profiles'
-import { FullPageSpinner } from '@/components/ui'
+import { Button, ButtonVariant, FullPageSpinner } from '@/components/ui'
 import { EXPLORER_NAMESPACE } from '@/utils/constants'
 import { route } from '@/utils/route'
-import { useRouter } from 'next/navigation'
-import { useEffect, useMemo } from 'react'
+import { useMemo } from 'react'
 import { ProfileContent } from './profile-content'
 
 interface Props {
@@ -13,15 +12,9 @@ interface Props {
 }
 
 export function ProfileWithWallet({ walletAddress }: Props) {
-  const router = useRouter()
   const { profiles, loading, error } = useGetProfiles({
     walletAddress,
   })
-  useEffect(() => {
-    if (error) {
-      router.push(route('home'))
-    }
-  }, [error, router])
 
   const profileInfo = useMemo(() => {
     return (
@@ -33,6 +26,17 @@ export function ProfileWithWallet({ walletAddress }: Props) {
 
   if (loading) {
     return <FullPageSpinner />
+  }
+
+  if (error) {
+    return (
+      <div className="w-full flex items-center justify-center pt-[200px] text-lg flex-col gap-4">
+        Profile not found
+        <Button variant={ButtonVariant.OUTLINE} href={route('home')}>
+          go back home
+        </Button>
+      </div>
+    )
   }
 
   return (

--- a/src/components/profile/components/profile-with-wallet.tsx
+++ b/src/components/profile/components/profile-with-wallet.tsx
@@ -3,7 +3,9 @@
 import { useGetProfiles } from '@/components/tapestry/hooks/use-get-profiles'
 import { FullPageSpinner } from '@/components/ui'
 import { EXPLORER_NAMESPACE } from '@/utils/constants'
-import { useMemo } from 'react'
+import { route } from '@/utils/route'
+import { useRouter } from 'next/navigation'
+import { useEffect, useMemo } from 'react'
 import { ProfileContent } from './profile-content'
 
 interface Props {
@@ -11,9 +13,15 @@ interface Props {
 }
 
 export function ProfileWithWallet({ walletAddress }: Props) {
-  const { profiles, loading } = useGetProfiles({
+  const router = useRouter()
+  const { profiles, loading, error } = useGetProfiles({
     walletAddress,
   })
+  useEffect(() => {
+    if (error) {
+      router.push(route('home'))
+    }
+  }, [error, router])
 
   const profileInfo = useMemo(() => {
     return (

--- a/src/components/swap/components/swap-elements/pay.tsx
+++ b/src/components/swap/components/swap-elements/pay.tsx
@@ -109,7 +109,7 @@ export function Pay({
                 alt={`${inputTokenSymbol || 'Token'} logo`}
                 width={32}
                 height={32}
-                className="rounded-full aspect-square object-cover"
+                className="rounded-full aspect-square object-cover max-w-[32px] max-h-[32px]"
               />
             ) : (
               <span className="rounded-full h-[32px] w-[32px] bg-background" />

--- a/src/components/swap/components/swap-elements/received.tsx
+++ b/src/components/swap/components/swap-elements/received.tsx
@@ -98,7 +98,7 @@ export function Receive({ setShowOutputTokenSearch }: Props) {
                   alt={`${outputTokenSymbol || 'Token'} logo`}
                   width={32}
                   height={32}
-                  className="rounded-full aspect-square object-cover"
+                  className="rounded-full aspect-square object-cover max-w-[32px] max-h-[32px]"
                 />
               ) : (
                 <span className="rounded-full h-[32px] w-[32px] bg-background" />

--- a/src/components/tapestry/hooks/use-unfollow-user.ts
+++ b/src/components/tapestry/hooks/use-unfollow-user.ts
@@ -2,9 +2,9 @@
 
 import { useMutation } from '@/utils/api'
 
-export const useFollowUser = () => {
+export const useUnfollowUser = () => {
   const {
-    mutate: followUser,
+    mutate: unfollowUser,
     loading,
     error,
     data,
@@ -15,11 +15,11 @@ export const useFollowUser = () => {
       followeeUsername: string
     }
   >({
-    endpoint: 'followers/add',
+    endpoint: 'followers/remove',
   })
 
   return {
-    followUser,
+    unfollowUser,
     loading,
     error,
     data,

--- a/src/components/tapestry/models/profiles.models.ts
+++ b/src/components/tapestry/models/profiles.models.ts
@@ -135,3 +135,8 @@ export interface IExternalNamespace {
   namespace: INameSpace
   profiles: IGetProfilesResponseEntry[]
 }
+
+export interface IFollowersAddRemoveInput {
+  followerUsername: string
+  followeeUsername: string
+}


### PR DESCRIPTION
	•	Fixed the profile link in the left menu on mobile view
	•	Made some adjustments to the Solid Score display
	•	Improved the follow functionality
	•	Profiles that didn’t exist on Tapestry used to trigger a 500 error — I updated this to return a 404 instead to clean up Vercel logs. If a profile doesn’t exist now, the user is redirected to the homepage
	•	Fixed an image sizing issue in the swap tray
	•	Also resolved a problem where token holder images occasionally failed to load
	•	Added the ability to unfollow a user
