### PR TITLE
TAP-1284 external profile routing

### DIFF
--- a/src/components/profile/components/profile-external-profile.tsx
+++ b/src/components/profile/components/profile-external-profile.tsx
@@ -34,14 +34,12 @@ export function ProfileExternalProfile({ profile }: Props) {
                     id: profile.profile.username,
                   })
                 : profile.namespace.userProfileURL
-                ? route('namespaceProfile', {
-                    id: profile.namespace.name,
-                    profile:
-                      profile.namespace.name === 'tribe.run' &&
-                      profile.wallet?.address
-                        ? profile.wallet.address
-                        : profile.profile.username,
-                  })
+                ? `${profile.namespace.userProfileURL}/${
+                    profile.namespace.name === 'tribe.run' &&
+                    profile.wallet?.address
+                      ? profile.wallet.address
+                      : profile.profile.username
+                  }`
                 : `/${profile.namespace.name}/${profile.profile.username}`
             }
             newTab={profile.namespace.name !== EXPLORER_NAMESPACE}


### PR DESCRIPTION
changes the logic to:
If it's an EXPLORER_NAMESPACE profile, use the internal entity route
If the namespace has a userProfileURL, concatenate it with the username to create the full external URL (e.g., https://tapai.gg/marcus)
Otherwise, fall back to the internal namespace route