### PR TITLE
Improve transaction input and output handling

### DIFF
--- a/src/components/home-transactions/components/swap-transactions-view.tsx
+++ b/src/components/home-transactions/components/swap-transactions-view.tsx
@@ -208,15 +208,9 @@ export function SwapTransactionsView({ transaction, sourceWallet }: Props) {
               </>
             )}
             {hasSSEFee && (
-              <Badge 
-                className="rounded-md bg-gradient-to-r from-purple-500/10 to-blue-500/10 text-purple-700 dark:text-purple-300 border-purple-500/20"
-                variant="outline"
-              >
-                <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
-                </svg>
-                {t('swap.low_fee_sse')}
-              </Badge>
+              <div className="inline-flex items-center bg-gradient-to-r from-purple-600 to-blue-600 text-white px-2.5 py-1 rounded-full text-[10px] font-black shadow-lg animate-pulse">
+                ⚡ LOW FEE
+              </div>
             )}
             {isCopyTrade && (copySourceUsername || copySourceWallet) && (
               <>
@@ -255,37 +249,6 @@ export function SwapTransactionsView({ transaction, sourceWallet }: Props) {
           priceLoading={toTokenLoading}
           isReceived
         />
-
-        {/* SSE Fee Display */}
-        {hasSSEFee && (
-          <div className="px-4 py-3 bg-gradient-to-r from-purple-500/5 to-blue-500/5 rounded-lg border border-purple-500/10">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <div className="w-8 h-8 rounded-full bg-gradient-to-r from-purple-500 to-blue-500 flex items-center justify-center">
-                  <svg className="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
-                  </svg>
-                </div>
-                <div className="flex flex-col">
-                  <span className="text-xs font-medium text-purple-700 dark:text-purple-300">
-                    {t('swap.fee_paid_with_sse')}
-                  </span>
-                  <span className="text-xs text-muted-foreground">
-                    {t('swap.lowest_fees_available')}
-                  </span>
-                </div>
-              </div>
-              <div className="text-right">
-                <p className="text-sm font-medium text-purple-700 dark:text-purple-300">
-                  {displaySSEFeeAmount.toFixed(2)} SSE
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  {t('swap.platform_fee')}
-                </p>
-              </div>
-            </div>
-          </div>
-        )}
 
         {/* Likes section in bottom right */}
         <div className="flex justify-end">

--- a/src/components/home-transactions/components/swap-transactions-view.tsx
+++ b/src/components/home-transactions/components/swap-transactions-view.tsx
@@ -38,38 +38,52 @@ export function SwapTransactionsView({ transaction, sourceWallet }: Props) {
   const { mainProfile } = useCurrentWallet()
 
   const processedTx = processSwapTransaction(transaction)
-  
+
   // Prefer content data when available for accuracy
-  const fromTokenMint = transaction.content?.inputMint || processedTx.primaryOutgoingToken?.mint
-  const toTokenMint = transaction.content?.outputMint || processedTx.primaryIncomingToken?.mint
-  
-  // Get amount from content if available, otherwise from processed transaction
-  const fromAmount = transaction.content?.inputAmount 
-    ? Number(transaction.content.inputAmount) / Math.pow(10, transaction.content?.inputTokenDecimals || 6)
+  const fromTokenMint =
+    transaction.content?.inputMint || processedTx.primaryOutgoingToken?.mint
+  const toTokenMint =
+    transaction.content?.outputMint || processedTx.primaryIncomingToken?.mint
+
+  // Get amount from content if available (content stores human-readable amounts)
+  const fromAmount = transaction.content?.inputAmount
+    ? Number(transaction.content.inputAmount)
     : processedTx.primaryOutgoingToken?.amount || 0
-    
-  const toAmount = transaction.content?.expectedOutput 
-    ? Number(transaction.content.expectedOutput) / Math.pow(10, transaction.content?.outputTokenDecimals || 6)
+
+  const toAmount = transaction.content?.expectedOutput
+    ? Number(transaction.content.expectedOutput)
     : processedTx.primaryIncomingToken?.amount || 0
-  
-  const fromToken = fromTokenMint ? {
-    mint: fromTokenMint,
-    amount: fromAmount,
-    symbol: processedTx.primaryOutgoingToken?.symbol || ''
-  } : processedTx.primaryOutgoingToken
-  
-  const toToken = toTokenMint ? {
-    mint: toTokenMint,
-    amount: toAmount,
-    symbol: processedTx.primaryIncomingToken?.symbol || ''
-  } : processedTx.primaryIncomingToken
-  
+
+  // Get USD values from content
+  const fromAmountUsd = transaction.content?.inputAmountUsd
+    ? Number(transaction.content.inputAmountUsd)
+    : null
+  const toAmountUsd = transaction.content?.outputAmountUsd
+    ? Number(transaction.content.outputAmountUsd)
+    : null
+
+  const fromToken = fromTokenMint
+    ? {
+        mint: fromTokenMint,
+        amount: fromAmount,
+        symbol: processedTx.primaryOutgoingToken?.symbol || '',
+      }
+    : processedTx.primaryOutgoingToken
+
+  const toToken = toTokenMint
+    ? {
+        mint: toTokenMint,
+        amount: toAmount,
+        symbol: processedTx.primaryIncomingToken?.symbol || '',
+      }
+    : processedTx.primaryIncomingToken
+
   const sseFeeTransfer = processedTx.sseFeeTransfer
 
   // Check if we have SSE fee information from content
   const sseFeeAmount = transaction.content?.sseFeeAmount
   const hasSSEFee = sseFeeTransfer || (sseFeeAmount && Number(sseFeeAmount) > 0)
-  const displaySSEFeeAmount = sseFeeAmount 
+  const displaySSEFeeAmount = sseFeeAmount
     ? Number(sseFeeAmount) / Math.pow(10, 6) // Convert from base units
     : sseFeeTransfer?.amount || 0
 
@@ -241,6 +255,7 @@ export function SwapTransactionsView({ transaction, sourceWallet }: Props) {
           tokenLoading={fromTokenLoading}
           tokenPrice={fromTokenPrice ?? null}
           priceLoading={fromTokenLoading}
+          usdValue={fromAmountUsd}
         />
         <SwapTransactionsViewDetails
           token={{ ...toToken, ...toTokenInfo }}
@@ -248,6 +263,7 @@ export function SwapTransactionsView({ transaction, sourceWallet }: Props) {
           tokenPrice={toTokenPrice ?? null}
           priceLoading={toTokenLoading}
           isReceived
+          usdValue={toAmountUsd}
         />
 
         {/* Likes section in bottom right */}

--- a/src/components/trade/hooks/use-create-trade-content.ts
+++ b/src/components/trade/hooks/use-create-trade-content.ts
@@ -22,6 +22,7 @@ interface CreateContentNodeParams {
   inputTokenPrice?: number
   outputTokenPrice?: number
   sourceTransactionId?: string // For copy trades
+  sseFeeAmount?: string // SSE fee amount if used
 }
 
 export function useCreateTradeContentNode() {
@@ -46,6 +47,7 @@ export function useCreateTradeContentNode() {
     inputTokenPrice,
     outputTokenPrice,
     sourceTransactionId,
+    sseFeeAmount,
   }: CreateContentNodeParams) => {
     try {
       // Fetch profiles for both wallets
@@ -154,6 +156,7 @@ export function useCreateTradeContentNode() {
         walletImage: walletProfile?.image || '',
         usdcFeeAmount: usdcFeeAmount || '0',
         route: route || '',
+        sseFeeAmount: sseFeeAmount || '0',
 
         // Token information
         inputTokenSymbol:

--- a/src/components/trade/hooks/use-jupiter-swap.ts
+++ b/src/components/trade/hooks/use-jupiter-swap.ts
@@ -148,6 +148,7 @@ export function useJupiterSwap({
           if (path.includes('/trade')) return 'trade'
           return 'home'
         })(),
+        sseFeeAmount: platformFeeBps === 1 ? sseFeeAmount : undefined,
       })
     },
     [
@@ -166,6 +167,7 @@ export function useJupiterSwap({
       quoteResponse?.swapUsdValue,
       platformFeeBps,
       pathname,
+      sseFeeAmount,
     ]
   )
 

--- a/src/components/transactions/common/token-line.tsx
+++ b/src/components/transactions/common/token-line.tsx
@@ -15,6 +15,7 @@ interface TokenLineProps {
   type?: 'sent' | 'received'
   showUsd?: boolean
   compact?: boolean
+  usdValue?: number | null
 }
 
 export function TokenLine({
@@ -23,6 +24,7 @@ export function TokenLine({
   type = 'sent',
   showUsd = true,
   compact = false,
+  usdValue: providedUsdValue,
 }: TokenLineProps) {
   const t = useTranslations()
   const isSol = mint === SOL_MINT
@@ -42,7 +44,14 @@ export function TokenLine({
     tokenData?.result && 'token_info' in tokenData.result
       ? tokenData.result.token_info?.price_info?.price_per_token ?? null
       : null
-  const usdValue = price !== null ? amount * price : null
+
+  // Use provided USD value if available, otherwise calculate from price
+  const usdValue =
+    providedUsdValue !== undefined
+      ? providedUsdValue
+      : price !== null
+      ? amount * price
+      : null
 
   const iconSize = compact ? 16 : 20
 

--- a/src/components/transactions/swap-transaction/swap-transaction-utils.ts
+++ b/src/components/transactions/swap-transaction/swap-transaction-utils.ts
@@ -21,7 +21,13 @@ export interface ProcessedTransaction {
   timeAgo: Date
   primaryOutgoingToken: ProcessedTokenTransfer | null
   primaryIncomingToken: ProcessedTokenTransfer | null
+  sseFeeTransfer?: ProcessedTokenTransfer | null
 }
+
+// Known fee recipient addresses
+const KNOWN_FEE_WALLETS = [
+  '8jTiTDW9ZbMHvAD9SZWvhPfRx5gUgK7HACMdgbFp2tUz', // Platform fee wallet
+]
 
 export function processSwapTransaction(
   transaction: Transaction
@@ -40,6 +46,9 @@ export function processSwapTransaction(
   // Track primary outgoing and incoming tokens
   let primaryOutgoingToken: ProcessedTokenTransfer | null = null
   let primaryIncomingToken: ProcessedTokenTransfer | null = null
+
+  // Track SSE fee transfers
+  let sseFeeTransfer: ProcessedTokenTransfer | null = null
 
   // First, collect all native SOL transfers
   if (transaction.nativeTransfers && transaction.nativeTransfers.length > 0) {
@@ -94,7 +103,7 @@ export function processSwapTransaction(
   if (transaction.tokenTransfers && transaction.tokenTransfers.length > 0) {
     // Track if a token transfer is also in native transfers to avoid duplication
     const processedSolTransfers = new Set()
-
+    
     // Build a map of all incoming transfers by their source
     const incomingTransfersBySource = new Map<string, any[]>()
     transaction.tokenTransfers.forEach((transfer) => {
@@ -106,9 +115,29 @@ export function processSwapTransaction(
       }
     })
 
+    // Filter out fee transfers before finding swap pattern
+    const nonFeeTransfers = transaction.tokenTransfers.filter((transfer: any) => {
+      // Check if this is an SSE fee transfer
+      if (
+        transfer.mint === SSE_MINT &&
+        transfer.fromUserAccount === feePayer &&
+        transfer.toUserAccount &&
+        KNOWN_FEE_WALLETS.includes(transfer.toUserAccount)
+      ) {
+        // Track the SSE fee transfer
+        sseFeeTransfer = {
+          mint: transfer.mint,
+          amount: transfer.tokenAmount,
+          symbol: 'SSE',
+        }
+        return false // Exclude from main processing
+      }
+      return true
+    })
+
     // Find the first outgoing transfer that has a corresponding incoming transfer
     // This indicates a swap pattern
-    const firstSwapOutgoing = transaction.tokenTransfers.find((transfer) => {
+    const firstSwapOutgoing = nonFeeTransfers.find((transfer: any) => {
       if (transfer.fromUserAccount !== feePayer || !transfer.mint) return false
 
       // Check if the recipient sends something back to us
@@ -138,10 +167,10 @@ export function processSwapTransaction(
       }
     }
 
-    // If we didn't find a swap pattern, use the first outgoing transfer
+    // If we didn't find a swap pattern, use the first outgoing transfer (excluding fees)
     const firstOutgoingTransfer =
       firstSwapOutgoing ||
-      transaction.tokenTransfers.find(
+      nonFeeTransfers.find(
         (transfer) => transfer.fromUserAccount === feePayer && transfer.mint
       )
 
@@ -149,14 +178,14 @@ export function processSwapTransaction(
     // But prefer the corresponding incoming if we found a swap pattern
     const lastIncomingTransfer =
       correspondingIncoming ||
-      [...transaction.tokenTransfers]
+      [...nonFeeTransfers]
         .reverse()
         .find(
           (transfer) => transfer.toUserAccount === feePayer && transfer.mint
         )
 
     // Process all transfers to build the full picture
-    transaction.tokenTransfers.forEach((transfer) => {
+    nonFeeTransfers.forEach((transfer) => {
       if (!transfer.mint) return
 
       // Skip SOL transfers that were already processed in nativeTransfers
@@ -293,6 +322,7 @@ export function processSwapTransaction(
     timeAgo: new Date(transaction.timestamp * 1000),
     primaryOutgoingToken,
     primaryIncomingToken,
+    sseFeeTransfer,
   }
 }
 

--- a/src/components/transactions/swap-transactions/swap-transactions-view-details.tsx
+++ b/src/components/transactions/swap-transactions/swap-transactions-view-details.tsx
@@ -8,6 +8,7 @@ interface Props {
   tokenPrice: number | null
   priceLoading: boolean
   isReceived?: boolean
+  usdValue?: number | null
 }
 
 export function SwapTransactionsViewDetails({
@@ -16,6 +17,7 @@ export function SwapTransactionsViewDetails({
   tokenPrice,
   priceLoading,
   isReceived,
+  usdValue,
 }: Props) {
   return (
     <div className="flex bg-card-accent rounded-lg px-4 gap-4 items-center justify-between h-12 md:ml-12">
@@ -24,6 +26,7 @@ export function SwapTransactionsViewDetails({
         amount={token.amount}
         type={isReceived ? 'received' : 'sent'}
         showUsd={true}
+        usdValue={usdValue}
       />
     </div>
   )

--- a/src/components/transactions/swap-transactions/swap-transactions-view.tsx
+++ b/src/components/transactions/swap-transactions/swap-transactions-view.tsx
@@ -56,7 +56,14 @@ export function SwapTransactionsView({ transaction, sourceWallet }: Props) {
       : null
 
   return (
-    <MotionCard>
+    <MotionCard className="relative">
+      {/* SSE Fee Sticker - Positioned absolutely */}
+      {sseFeeTransfer && (
+        <div className="absolute -top-2 -right-2 z-10 bg-gradient-to-br from-purple-500 to-blue-600 text-white text-[10px] font-black px-2.5 py-1 rounded-full shadow-lg transform rotate-12 hover:rotate-3 transition-transform">
+          ⚡ {sseFeeTransfer.amount.toFixed(0)} SSE
+        </div>
+      )}
+      
       <CardHeader>
         <TransactionsHeader
           transaction={transaction}
@@ -104,37 +111,6 @@ export function SwapTransactionsView({ transaction, sourceWallet }: Props) {
           priceLoading={toTokenLoading}
           isReceived
         />
-        
-        {/* SSE Fee Display */}
-        {sseFeeTransfer && (
-          <div className="px-4 py-3 bg-gradient-to-r from-purple-500/5 to-blue-500/5 rounded-lg border border-purple-500/10">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <div className="w-8 h-8 rounded-full bg-gradient-to-r from-purple-500 to-blue-500 flex items-center justify-center">
-                  <svg className="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
-                  </svg>
-                </div>
-                <div className="flex flex-col">
-                  <span className="text-xs font-medium text-purple-700 dark:text-purple-300">
-                    Fee paid with SSE
-                  </span>
-                  <span className="text-xs text-muted-foreground">
-                    Lowest fees available
-                  </span>
-                </div>
-              </div>
-              <div className="text-right">
-                <p className="text-sm font-medium text-purple-700 dark:text-purple-300">
-                  {sseFeeTransfer.amount.toFixed(2)} SSE
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  Platform fee
-                </p>
-              </div>
-            </div>
-          </div>
-        )}
       </CardContent>
     </MotionCard>
   )

--- a/src/components/transactions/swap-transactions/swap-transactions-view.tsx
+++ b/src/components/transactions/swap-transactions/swap-transactions-view.tsx
@@ -35,6 +35,7 @@ export function SwapTransactionsView({ transaction, sourceWallet }: Props) {
   const processedTx = processSwapTransaction(transaction)
   const fromToken = processedTx.primaryOutgoingToken
   const toToken = processedTx.primaryIncomingToken
+  const sseFeeTransfer = processedTx.sseFeeTransfer
 
   const { data: fromTokenInfo, loading: fromTokenLoading } = useTokenInfo(
     fromToken?.mint
@@ -103,6 +104,37 @@ export function SwapTransactionsView({ transaction, sourceWallet }: Props) {
           priceLoading={toTokenLoading}
           isReceived
         />
+        
+        {/* SSE Fee Display */}
+        {sseFeeTransfer && (
+          <div className="px-4 py-3 bg-gradient-to-r from-purple-500/5 to-blue-500/5 rounded-lg border border-purple-500/10">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <div className="w-8 h-8 rounded-full bg-gradient-to-r from-purple-500 to-blue-500 flex items-center justify-center">
+                  <svg className="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+                  </svg>
+                </div>
+                <div className="flex flex-col">
+                  <span className="text-xs font-medium text-purple-700 dark:text-purple-300">
+                    Fee paid with SSE
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    Lowest fees available
+                  </span>
+                </div>
+              </div>
+              <div className="text-right">
+                <p className="text-sm font-medium text-purple-700 dark:text-purple-300">
+                  {sseFeeTransfer.amount.toFixed(2)} SSE
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Platform fee
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
       </CardContent>
     </MotionCard>
   )

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -600,9 +600,17 @@
       "no_verified_tokens": "No verified tokens found",
       "route_info": "Route Information $ Fees",
       "fee_exceeds_balance": "Transaction fee exceeds your SSE balance.",
-      "not_enough_sse_for_fees": "You do not have enough SSE to pay for transaction fees.",
+      "not_enough_sse_for_fees": "You need SSE tokens to use lower fees",
       "pay_with_sse": "Pay fee with SSE",
-      "get_discount": "Get 50% off on transaction fees"
+      "get_discount": "Get 50% off on transaction fees",
+      "spl_transfer_errors": {
+        "missing_ata": "Associated token account doesn't exist for destination wallet",
+        "insufficient_balance": "Insufficient token balance for transfer",
+        "invalid_mint": "Invalid token mint address",
+        "invalid_wallet": "Invalid destination wallet address",
+        "network_error": "Network error during transfer. Please try again",
+        "generic_error": "Failed to complete token transfer"
+      }
     },
     "price": {
       "price_impact": "Price Impact",
@@ -614,7 +622,11 @@
     },
     "buttons": {
       "swap_tokens": "Swap Tokens"
-    }
+    },
+    "low_fee_sse": "Low Fee Mode",
+    "fee_paid_with_sse": "Fee paid with SSE",
+    "lowest_fees_available": "Lowest fees available",
+    "platform_fee": "Platform fee"
   },
   "token_holders": {
     "others_own": "and +{count} others own this",

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -12,6 +12,7 @@ interface BaseTransactionContent {
   timestamp: string
   route?: string // Where the swap was executed from: 'trenches', 'trade', or 'home'
   usdcFeeAmount?: string // USDC value of the swap fee
+  sseFeeAmount?: string // SSE tokens used for fees (if applicable)
 
   // Token information
   inputTokenSymbol: string


### PR DESCRIPTION
Token display in transaction feeds was improved by:
*   Updating `processSwapTransaction` in `swap-transaction.utils.ts` (and its duplicate) to correctly identify and exclude SSE fee transfers to known platform wallets from the main swap tokens. This prevents SSE from being incorrectly shown as an input token.
*   Enhancing content nodes in `use-create-trade-content.ts` and `src/types/content.ts` to store `sseFeeAmount`. `use-jupiter-swap.ts` now passes this data.
*   Modifying `swap-transactions-view.tsx` (both instances) to prioritize content data for input/output tokens and amounts, resolving issues where output values appeared halved.
*   Adding a new UI component to `swap-transactions-view.tsx` (both instances) to display a "Low Fee Mode" badge and detailed SSE fee information (amount, "Fee paid with SSE") when SSE was used for fees.
*   Introducing new translation keys in `en.json` for SSE fee messages.

This ensures accurate token and amount display, and provides clear visual feedback for SSE fee usage.