### PR TITLE
Create SSE leaderboard page

### DIFF
--- a/src/components/solid-score/components/leaderboard/leaderboard-content.tsx
+++ b/src/components/solid-score/components/leaderboard/leaderboard-content.tsx
@@ -2,27 +2,31 @@
 
 import { ShareSolidScoreDialog } from '@/components/pudgy/components/share-tweet-dialog/share-solid-score-dialog'
 import { useSolidScoreLeaderboard } from '@/components/solid-score/hooks/use-solid-score-leaderboard'
+import { useScoreLeaderboard } from '@/hooks/use-user-score'
 import { Button, ButtonSize, Spinner } from '@/components/ui'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs/tabs'
 import { useCurrentWallet } from '@/utils/use-current-wallet'
 import { cn } from '@/utils/utils'
 import { useTranslations } from 'next-intl'
 import { useState } from 'react'
 import { DataTableLeaderboard } from './data-table-leaderboard'
 import { DataTableUserPosition } from './data-table-user-position'
+import { SSELeaderboard } from './sse-leaderboard'
 
 export function LeaderboardContent() {
-  const { data, loading } = useSolidScoreLeaderboard()
+  const { data: solidScoreData, loading: solidScoreLoading } = useSolidScoreLeaderboard()
   const { mainProfile, loading: walletLoading } = useCurrentWallet()
   const [open, setOpen] = useState(false)
+  const [activeTab, setActiveTab] = useState('sse-scores')
   const t = useTranslations('menu.solid_score.leaderboard')
 
   const hasRevealedShare = !!mainProfile?.userHasClickedOnShareHisSolidScore
 
-  const isUserInTopList = data?.some(
+  const isUserInTopList = solidScoreData?.some(
     (item) => item.username === mainProfile?.username
   )
 
-  if (walletLoading || loading) {
+  if (walletLoading) {
     return (
       <div className="flex items-center justify-center h-full">
         <Spinner />
@@ -36,43 +40,70 @@ export function LeaderboardContent() {
 
   return (
     <div className="space-y-4">
-      <h1 className="text-2xl font-bold">{t('title')}</h1>
-      <div className="space-y-4 relative">
-        <div
-          className={cn({
-            'blur-sm pointer-events-none': !hasRevealedShare,
-          })}
-        >
-          <DataTableLeaderboard
-            data={data ?? []}
-            loading={loading}
-            currentUsername={mainProfile?.username}
-          />
-          {mainProfile && !isUserInTopList && <DataTableUserPosition />}
-        </div>
-        {!hasRevealedShare && (
-          <div className="absolute inset-0 flex items-center justify-center">
-            <div className="max-w-xs grid gap-5 border border-foreground/20 bg-modal backdrop-blur-xl text-modal-foreground p-6 shadow-lg rounded outline-hidden">
-              <div className="flex flex-col gap-2 text-md text-center">
-                <p className="font-bold">{t('locked.title')}</p>
-                <p>{t('locked.description')}</p>
-              </div>
-              <Button size={ButtonSize.LG} onClick={() => setOpen(true)}>
-                {t('locked.unlock_button')}
-              </Button>
-            </div>
-          </div>
-        )}
-        {hasRevealedShare && (
-          <Button
-            onClick={() => setOpen(true)}
-            className="w-full"
-            size={ButtonSize.LG}
+      <h1 className="text-3xl font-bold bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent">
+        {t('title')}
+      </h1>
+      
+      <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
+        <TabsList className="grid w-full grid-cols-2 bg-background/50 backdrop-blur-sm border border-foreground/10 rounded-lg p-1">
+          <TabsTrigger 
+            value="sse-scores" 
+            className="data-[state=active]:bg-primary/10 data-[state=active]:text-primary font-semibold"
           >
-            {t('share_button')}
-          </Button>
-        )}
-      </div>
+            {t('tabs.sse_scores')}
+          </TabsTrigger>
+          <TabsTrigger 
+            value="solid-scores"
+            className="data-[state=active]:bg-primary/10 data-[state=active]:text-primary font-semibold"
+          >
+            {t('tabs.solid_scores')}
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="sse-scores" className="space-y-4">
+          <SSELeaderboard currentUsername={mainProfile?.username} />
+        </TabsContent>
+
+        <TabsContent value="solid-scores" className="space-y-4">
+          <div className="space-y-4 relative">
+            <div
+              className={cn({
+                'blur-sm pointer-events-none': !hasRevealedShare,
+              })}
+            >
+              <DataTableLeaderboard
+                data={solidScoreData ?? []}
+                loading={solidScoreLoading}
+                currentUsername={mainProfile?.username}
+              />
+              {mainProfile && !isUserInTopList && <DataTableUserPosition />}
+            </div>
+            {!hasRevealedShare && (
+              <div className="absolute inset-0 flex items-center justify-center">
+                <div className="max-w-xs grid gap-5 border border-foreground/20 bg-modal backdrop-blur-xl text-modal-foreground p-6 shadow-lg rounded outline-hidden">
+                  <div className="flex flex-col gap-2 text-md text-center">
+                    <p className="font-bold">{t('locked.title')}</p>
+                    <p>{t('locked.description')}</p>
+                  </div>
+                  <Button size={ButtonSize.LG} onClick={() => setOpen(true)}>
+                    {t('locked.unlock_button')}
+                  </Button>
+                </div>
+              </div>
+            )}
+            {hasRevealedShare && (
+              <Button
+                onClick={() => setOpen(true)}
+                className="w-full"
+                size={ButtonSize.LG}
+              >
+                {t('share_button')}
+              </Button>
+            )}
+          </div>
+        </TabsContent>
+      </Tabs>
+
       <ShareSolidScoreDialog open={open} setOpen={setOpen} />
     </div>
   )

--- a/src/components/solid-score/components/leaderboard/sse-leaderboard.tsx
+++ b/src/components/solid-score/components/leaderboard/sse-leaderboard.tsx
@@ -1,0 +1,196 @@
+'use client'
+
+import { useScoreLeaderboard } from '@/hooks/use-user-score'
+import { Button, ButtonSize, ButtonVariant } from '@/components/ui'
+import { Avatar } from '@/components/ui/avatar/avatar'
+import { DataTable } from '@/components/ui/table/data-table'
+import { SortableHeader } from '@/components/ui/table/sortable-header'
+import { formatSmartNumber } from '@/utils/formatting/format-number'
+import { route } from '@/utils/route'
+import { cn } from '@/utils/utils'
+import { ColumnDef } from '@tanstack/react-table'
+import { useTranslations } from 'next-intl'
+import { useState } from 'react'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs/tabs'
+import { SSEUserPosition } from './sse-user-position'
+
+const baseColumnStyles = {
+  rank: 'md:w-[100px]',
+  username: 'flex-1 md:min-w-[200px]',
+  score: 'md:w-[150px]',
+}
+
+interface SSELeaderboardProps {
+  currentUsername?: string
+}
+
+type TimeframeType = 'lifetime' | 'daily' | 'weekly' | 'monthly'
+
+export function SSELeaderboard({ currentUsername }: SSELeaderboardProps) {
+  const [timeframe, setTimeframe] = useState<TimeframeType>('lifetime')
+  const { leaderboard, loading } = useScoreLeaderboard({ 
+    timeframe,
+    limit: 100 
+  })
+  const t = useTranslations('menu.solid_score.leaderboard')
+  const tTable = useTranslations('menu.solid_score.leaderboard.table')
+
+  const isUserInTopList = leaderboard.some(
+    (entry: { username?: string; userId: string }) => entry.username === currentUsername || entry.userId === currentUsername
+  )
+
+  const columns: ColumnDef<{
+    userId: string
+    username?: string
+    score: number
+    rank: number
+    profileImage?: string | null
+  }>[] = [
+    {
+      accessorKey: 'rank',
+      header: ({ column }) => (
+        <div className={baseColumnStyles.rank}>
+          <SortableHeader label={tTable('columns.rank')} column={column} />
+        </div>
+      ),
+      cell: ({ getValue, row }) => {
+        const value = getValue<number>()
+        const isCurrentUser = row.original.username === currentUsername || 
+                            row.original.userId === currentUsername
+        return (
+          <div
+            className={cn(baseColumnStyles.rank, {
+              'text-primary font-bold': isCurrentUser,
+            })}
+          >
+            <span className="text-muted-foreground">#</span>
+            <span className="font-semibold">{value}</span>
+          </div>
+        )
+      },
+    },
+    {
+      accessorKey: 'username',
+      header: ({ column }) => (
+        <div className={baseColumnStyles.username}>
+          <SortableHeader label={tTable('columns.username')} column={column} />
+        </div>
+      ),
+      cell: ({ row }) => {
+        const username = row.original.username || row.original.userId
+        const isCurrentUser = username === currentUsername
+
+        return (
+          <div className={baseColumnStyles.username}>
+            <Button
+              variant={ButtonVariant.LINK}
+              href={route('entity', { id: username })}
+              className={cn('p-0 h-auto max-w-[100px] md:max-w-[200px]', {
+                'text-primary font-bold': isCurrentUser,
+              })}
+            >
+              <Avatar
+                imageUrl={row.original.profileImage || undefined}
+                username={username}
+                size={24}
+                className="w-6 h-6"
+              />
+              <p className="truncate">{username}</p>
+            </Button>
+          </div>
+        )
+      },
+    },
+    {
+      accessorKey: 'score',
+      header: ({ column }) => (
+        <div className={baseColumnStyles.score}>
+          <SortableHeader label={tTable('columns.score')} column={column} />
+        </div>
+      ),
+      cell: ({ getValue, row }) => {
+        const value = getValue<number>()
+        const isCurrentUser = row.original.username === currentUsername || 
+                            row.original.userId === currentUsername
+        return (
+          <div
+            className={cn(baseColumnStyles.score, {
+              'text-primary font-bold': isCurrentUser,
+            })}
+          >
+            <div className="flex items-center gap-1">
+              <span className="text-lg">🔥</span>
+              <span className="font-semibold">
+                {formatSmartNumber(value || 0, {
+                  minimumFractionDigits: 0,
+                  maximumFractionDigits: 0,
+                })}
+              </span>
+            </div>
+          </div>
+        )
+      },
+    },
+  ]
+
+  const TimeframeSelector = () => (
+    <div className="mb-4">
+      <Tabs value={timeframe} onValueChange={(value) => setTimeframe(value as TimeframeType)}>
+        <TabsList className="grid w-full grid-cols-4 bg-background/50 backdrop-blur-sm">
+          <TabsTrigger value="lifetime" className="data-[state=active]:bg-primary/10">
+            {t('tabs.timeframes.all_time')}
+          </TabsTrigger>
+          <TabsTrigger value="monthly" className="data-[state=active]:bg-primary/10">
+            {t('tabs.timeframes.monthly')}
+          </TabsTrigger>
+          <TabsTrigger value="weekly" className="data-[state=active]:bg-primary/10">
+            {t('tabs.timeframes.weekly')}
+          </TabsTrigger>
+          <TabsTrigger value="daily" className="data-[state=active]:bg-primary/10">
+            {t('tabs.timeframes.today')}
+          </TabsTrigger>
+        </TabsList>
+      </Tabs>
+    </div>
+  )
+
+  return (
+    <div className="space-y-4">
+      <div className="bg-gradient-to-r from-primary/10 to-secondary/10 rounded-lg p-4 border border-primary/20">
+        <h3 className="text-lg font-semibold mb-2">{t('sse_scores.title')}</h3>
+        <p className="text-sm text-muted-foreground">
+          {t('sse_scores.description')}
+        </p>
+      </div>
+
+      <TimeframeSelector />
+
+      <DataTable
+        data={leaderboard}
+        columns={columns}
+        loading={loading}
+        tableClassName="h-[600px]"
+        isSmall
+      />
+
+      {currentUsername && !isUserInTopList && (
+        <SSEUserPosition username={currentUsername} timeframe={timeframe} />
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="bg-background/50 backdrop-blur-sm rounded-lg p-4 border border-foreground/10">
+          <h4 className="font-semibold text-sm mb-1">{t('sse_scores.categories.trading.title')}</h4>
+          <p className="text-xs text-muted-foreground">{t('sse_scores.categories.trading.description')}</p>
+        </div>
+        <div className="bg-background/50 backdrop-blur-sm rounded-lg p-4 border border-foreground/10">
+          <h4 className="font-semibold text-sm mb-1">{t('sse_scores.categories.staking.title')}</h4>
+          <p className="text-xs text-muted-foreground">{t('sse_scores.categories.staking.description')}</p>
+        </div>
+        <div className="bg-background/50 backdrop-blur-sm rounded-lg p-4 border border-foreground/10">
+          <h4 className="font-semibold text-sm mb-1">{t('sse_scores.categories.social.title')}</h4>
+          <p className="text-xs text-muted-foreground">{t('sse_scores.categories.social.description')}</p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/solid-score/components/leaderboard/sse-user-position.tsx
+++ b/src/components/solid-score/components/leaderboard/sse-user-position.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useUserScore } from '@/hooks/use-user-score'
+import { Avatar } from '@/components/ui/avatar/avatar'
+import { Button, ButtonVariant } from '@/components/ui'
+import { route } from '@/utils/route'
+import { formatSmartNumber } from '@/utils/formatting/format-number'
+import { cn } from '@/utils/utils'
+import { useTranslations } from 'next-intl'
+
+interface SSEUserPositionProps {
+  username: string
+  timeframe: 'lifetime' | 'daily' | 'weekly' | 'monthly'
+}
+
+export function SSEUserPosition({ username, timeframe }: SSEUserPositionProps) {
+  const { score, rank, percentile, loading } = useUserScore({
+    userId: username,
+    timeframe,
+  })
+  const t = useTranslations('menu.solid_score.leaderboard')
+
+  if (loading || !rank || rank <= 100) {
+    // User is already in the leaderboard or data is loading
+    return null
+  }
+
+  return (
+    <div className="mt-4 p-4 bg-primary/5 rounded-lg border border-primary/20">
+      <p className="text-sm text-muted-foreground mb-2">{t('sse_scores.your_position')}</p>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="text-primary font-bold">#{rank}</div>
+          <Button
+            variant={ButtonVariant.LINK}
+            href={route('entity', { id: username })}
+            className="p-0 h-auto"
+          >
+            <Avatar username={username} size={24} className="w-6 h-6" />
+            <p className="truncate font-semibold">{username}</p>
+          </Button>
+        </div>
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-1">
+            <span className="text-lg">🔥</span>
+            <span className="font-semibold">
+              {formatSmartNumber(score, {
+                minimumFractionDigits: 0,
+                maximumFractionDigits: 0,
+              })}
+            </span>
+          </div>
+          <div className="text-sm text-muted-foreground">
+            Top {percentile}%
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -82,6 +82,36 @@
       "leaderboard": {
         "title": "Leaderboard",
         "share_button": "Share your SOLID score",
+        "tabs": {
+          "sse_scores": "SSE Scores 🔥",
+          "solid_scores": "SOLID Scores",
+          "timeframes": {
+            "all_time": "All Time",
+            "monthly": "Monthly", 
+            "weekly": "Weekly",
+            "today": "Today"
+          }
+        },
+        "sse_scores": {
+          "title": "🏆 SSE Activity Scores",
+          "description": "Earn points for trading, staking, and engaging with the SSE ecosystem. The more active you are, the higher you rank!",
+          "your_position": "Your Position",
+          "categories": {
+            "trading": {
+              "title": "🎯 Trading",
+              "description": "Execute trades and copy successful traders"
+            },
+            "staking": {
+              "title": "💎 Staking", 
+              "description": "Stake SSE tokens to earn bonus points"
+            },
+            "social": {
+              "title": "🤝 Social",
+              "description": "Follow traders and engage with the community"
+            }
+          }
+        },
+        "share_button": "Share your SOLID score",
         "share_dialog": {
           "title": "🚀 You're on the board, but it's locked",
           "percentile_text": "Your score ranks you in the Top {percentile}% of SSE users!",


### PR DESCRIPTION
The leaderboard page was enhanced by introducing a tabbed interface to differentiate between SSE and SOLID scores.

*   **Tabbed Navigation**:
    *   `src/app/leaderboard/page.tsx` was modified to render `Tabs` from `@/components/ui/tabs/tabs`.
    *   Two tabs were added: "SSE Scores" and "SOLID Scores".
    *   "SSE Scores" is set as the default and most prominent tab.

*   **SSE Leaderboard Implementation**:
    *   A new component, `src/components/solid-score/components/leaderboard/sse-leaderboard.tsx`, was created to display user scores from the Redis-based scoring system.
    *   This component utilizes the `useScoreLeaderboard` hook to fetch data.
    *   It includes timeframe filters (All Time, Monthly, Weekly, Today) and displays rank, username, and score with visual indicators.
    *   A new component, `src/components/solid-score/components/leaderboard/sse-user-position.tsx`, was added to show the current user's rank below the table if they are not in the top 100.

*   **SOLID Leaderboard Integration**:
    *   The existing SOLID score leaderboard logic was moved into its own `TabsContent` section within `src/app/leaderboard/page.tsx`.
    *   The "share to unlock" mechanism for SOLID scores was preserved, maintaining its restricted access.

*   **Internationalization**:
    *   New translation keys for the tabs, SSE leaderboard title, description, timeframes, and scoring categories were added to `src/messages/en.json`.