### PR TITLE
fix picture upload

### DIFF
--- a/src/components/onboarding/components/add-profile-image.tsx
+++ b/src/components/onboarding/components/add-profile-image.tsx
@@ -7,6 +7,7 @@ import {
   useUploadFiles,
 } from '@/components/ui'
 import { createURL, FetchMethod, fetchWrapper } from '@/utils/api'
+import { getAuthToken } from '@dynamic-labs/sdk-react-core'
 import { useCurrentWallet } from '@/utils/use-current-wallet'
 import { cn } from '@/utils/utils'
 import { UploadIcon } from 'lucide-react'
@@ -36,9 +37,12 @@ export function AddProfileImage({
   })
   const { uploadFiles, UploadFilesModal } = useUploadFiles({
     getUploadUrl: async (file: File) => {
+      const authToken = getAuthToken()
+
       const response = await fetchWrapper<{ postUrl: string }>({
         method: FetchMethod.POST,
         endpoint: `upload/${file.name}`,
+        jwt: authToken,
       })
       return response.postUrl
     },

--- a/src/components/profile/components/profile-image-editor.tsx
+++ b/src/components/profile/components/profile-image-editor.tsx
@@ -5,6 +5,7 @@ import { useUpdateProfile } from '@/components/tapestry/hooks/use-update-profile
 import { useUploadFiles } from '@/components/ui'
 import { Avatar } from '@/components/ui/avatar/avatar'
 import { createURL, FetchMethod, fetchWrapper } from '@/utils/api'
+import { getAuthToken } from '@dynamic-labs/sdk-react-core'
 import { useCurrentWallet } from '@/utils/use-current-wallet'
 import { Camera } from 'lucide-react'
 import { useState } from 'react'
@@ -36,9 +37,12 @@ export function ProfileImageEditor({
 
   const { uploadFiles, UploadFilesModal } = useUploadFiles({
     getUploadUrl: async (file: File) => {
+      const authToken = getAuthToken()
+
       const response = await fetchWrapper<{ postUrl: string }>({
         method: FetchMethod.POST,
         endpoint: `upload/${file.name}`,
+        jwt: authToken,
       })
       return response.postUrl
     },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how upload URLs are requested by adding JWT auth; if token retrieval is unavailable/incorrect, profile image uploads could fail for users.
> 
> **Overview**
> Adds authenticated upload URL requests for profile picture uploads by retrieving a Dynamic auth token via `getAuthToken()` and passing it as `jwt` to `fetchWrapper`.
> 
> This change is applied in both onboarding (`AddProfileImage`) and the profile editor (`ProfileImageEditor`), ensuring the `POST upload/{filename}` call includes a `Bearer` token.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0003bc53c5cb81af077d86c9b633ee7770f4dca3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->